### PR TITLE
chore: Switch to using ubuntu-20.04-large runners

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,14 +11,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-20.04-large
             RUNNER_OS: linux
           - os: macos-11
             RUNNER_OS: darwin
           - os: windows-2019
             RUNNER_OS: windows
         goarch: [amd64, arm64]
-        os: [ubuntu-20.04, macos-11, windows-2019]
+        os: [ubuntu-20.04-large, macos-11, windows-2019]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2


### PR DESCRIPTION
- Ubuntu 20.04 runners have been discontinued https://github.com/actions/runner-images/issues/11101